### PR TITLE
Add global schema with shipping details

### DIFF
--- a/public/globalSchema.js
+++ b/public/globalSchema.js
@@ -1,0 +1,58 @@
+export const EU_COUNTRIES = [
+  "AT",
+  "BE",
+  "BG",
+  "HR",
+  "CY",
+  "CZ",
+  "DK",
+  "EE",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "HU",
+  "IE",
+  "IT",
+  "LV",
+  "LT",
+  "LU",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SK",
+  "SI",
+  "ES",
+  "SE",
+];
+
+export const GLOBAL_SCHEMA = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@id": "#shippingDetails-eu",
+      "@type": "OfferShippingDetails",
+      shippingDestination: {
+        "@type": "DefinedRegion",
+        addressCountry: EU_COUNTRIES,
+      },
+    },
+    {
+      "@id": "#shippingDetails-world",
+      "@type": "OfferShippingDetails",
+      shippingDestination: {
+        "@type": "DefinedRegion",
+        addressCountry: "001",
+      },
+    },
+  ],
+};
+
+export function shippingDetailsRefsForHost(host) {
+  const base = host.replace(/\/$/, "");
+  return GLOBAL_SCHEMA["@graph"]
+    .filter((n) => n["@type"] === "OfferShippingDetails")
+    .map((n) => `${base}${n["@id"]}`);
+}

--- a/public/structuredData.js
+++ b/public/structuredData.js
@@ -1,0 +1,21 @@
+import { GLOBAL_SCHEMA, shippingDetailsRefsForHost } from "./globalSchema.js";
+
+export function buildMainJsonLd(host, product) {
+  const shippingRefs = shippingDetailsRefsForHost(host).map((id) => ({
+    "@id": id,
+  }));
+  const offer = {
+    "@type": "Offer",
+    price: product.price,
+    shippingDetails: shippingRefs,
+  };
+  const productNode = {
+    "@type": "Product",
+    name: product.name,
+    offers: offer,
+  };
+  return {
+    "@context": "https://schema.org",
+    "@graph": [...GLOBAL_SCHEMA["@graph"], productNode],
+  };
+}


### PR DESCRIPTION
## Summary
- add global schema describing EU and global shipping details
- build helper for combining global schema with product JSON-LD

## Testing
- `yarn lint:js`
- `node -e "import('./public/structuredData.js').then(m=>{const o=m.buildMainJsonLd('https://example.com', {name:'Widget', price:'10'}); console.log(JSON.stringify(o,null,2));})"`


------
https://chatgpt.com/codex/tasks/task_e_68b2d6a732088325be20109b18cb5bc8