### PR TITLE
Add plain JS MerchantReturnPolicy JSON-LD embed

### DIFF
--- a/scripts/merchant-return-policy.js
+++ b/scripts/merchant-return-policy.js
@@ -1,0 +1,19 @@
+(function () {
+  const { hostname, origin } = window.location;
+  const [subdomain] = hostname.split(".");
+
+  const policy = {
+    "@context": "https://schema.org",
+    "@type": "MerchantReturnPolicy",
+    url: `${origin}/legales/politica-de-devoluciones`,
+    name: `${subdomain ? `${subdomain} ` : ""}Return Policy`,
+    merchantReturnDays: 30,
+    returnFees: "https://schema.org/ReturnFeesCustomerResponsibility",
+    returnPolicyCategory: "https://schema.org/MerchantReturnFiniteReturnWindow",
+  };
+
+  const script = document.createElement("script");
+  script.type = "application/ld+json";
+  script.textContent = JSON.stringify(policy);
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
## Summary
- derive subdomain and build MerchantReturnPolicy JSON-LD in plain JavaScript
- link to return-policy URL and enumerate schema.org URLs
- append policy JSON-LD to document head via `textContent`

## Testing
- `npm run lint:js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd29824ca883258b4ca09812756e34